### PR TITLE
[#1] Todo create_at 컬럼 추가 및 표시

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy import TIMESTAMP, Column, Integer, String, Boolean, func
 from .database import Base
 
 
@@ -10,6 +10,7 @@ class Todo(Base):
     description = Column(String, nullable=True)
     completed = Column(Boolean, default=False)
     important = Column(Boolean, default=False)
+    created_at = Column(TIMESTAMP, server_default=func.now())
 
 
 class User(Base):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,3 +1,4 @@
+import datetime
 from pydantic import BaseModel
 
 
@@ -12,6 +13,7 @@ class TodoCreate(BaseModel):
 class Todo(TodoCreate):
     id: int
     completed: bool
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True

--- a/frontend/src/components/todo/todoItem.tsx
+++ b/frontend/src/components/todo/todoItem.tsx
@@ -11,7 +11,8 @@ type TodoItemProps = {
   title: string;
   description?: string;
   completed: boolean;
-  important?: boolean;
+  important?: boolean;  
+  created_at: string; 
 };
 
 export default function TodoItem({
@@ -19,7 +20,9 @@ export default function TodoItem({
   description,
   completed,
   important,
+  created_at,
 }: TodoItemProps) {
+
   const [isChecked, setIsChecked] = useState(completed);
 
   const handleToggle = () => {
@@ -27,7 +30,16 @@ export default function TodoItem({
     // TODO: 체크 상태 서버에 업데이트
   };
 
-  // TODO: 날짜 저장 필요
+  function formatDateRange(dateString: string) {
+    const startDate = new Date(dateString);
+    const endDate = new Date(startDate);
+    endDate.setDate(startDate.getDate() + 1);
+  
+    const format = (date: Date) => 
+      `${date.getFullYear()}.${(date.getMonth() + 1).toString().padStart(2, "0")}.${date.getDate().toString().padStart(2, "0")}`;
+  
+    return `${format(startDate)} ~ ${format(endDate)}`;
+  }
 
   return (
     <Card className="w-full p-5 rounded-2xl flex flex-col gap-3 shadow-sm">
@@ -65,7 +77,7 @@ export default function TodoItem({
 
       {/* 하단 영역 */}
       <div className="flex items-center justify-between text-sm text-gray-400">
-        {/* <span></span> TODO: 날짜 업데이트 */}
+        <span>{formatDateRange(created_at)}</span>
         {important && <Star/>}
       </div>
     </Card>

--- a/frontend/src/components/todo/todoList.tsx
+++ b/frontend/src/components/todo/todoList.tsx
@@ -6,6 +6,7 @@ type Todo = {
   description?: string;
   completed: boolean;
   important: boolean;
+  created_at: string; 
 };
 
 export default async function TodoList() {
@@ -24,6 +25,7 @@ export default async function TodoList() {
           description={todo.description}
           completed={todo.completed}
           important={todo.important}
+          created_at={todo.created_at}
         />
       ))}
     </div>


### PR DESCRIPTION
## 📋 작업 제목
[#1] Todo created_at 컬럼 추가 및 프론트 표시 기능

## 🛠️ 작업 내용
- todo 테이블에 created_at 컬럼 추가
- todo 생성 시 현재 시간(created_at) 저장
- 프론트엔드 todoItem 컴포넌트에 생성일자 범위 표시

## ✅ 체크리스트
- [x] 코드 빌드/실행 정상 확인
- [x] 기존 기능에 영향 없음
- [x] 관련 Issue 번호 연결 (Closes #1)

## 💬 추가 메모
- 날짜는 yyyy.mm.dd ~ yyyy.mm.dd+1 형식으로 표시됨
